### PR TITLE
Enhace access to OperaResponse on Requests

### DIFF
--- a/Sources/Common/OperaResult.swift
+++ b/Sources/Common/OperaResult.swift
@@ -43,6 +43,19 @@ public struct OperaResult {
 }
 
 extension OperaResult {
+    
+    public var operaResponse: OperaResponse? {
+        switch self.result {
+        case let .success(value):
+            return value
+        case .failure:
+            return nil
+        }
+    }
+    
+    public var httpResponse: HTTPURLResponse? {
+        return operaResponse?.response
+    }
 
     /**
      Generic response object serialization that returns a OperaDecodable instance.

--- a/Sources/Common/RouteType+Rx.swift
+++ b/Sources/Common/RouteType+Rx.swift
@@ -81,6 +81,32 @@ extension Reactive where Base: RouteType {
         }
         return (base.manager as! RxManager).rx.completableResponse(base)
     }
+    /**
+     Returns a `Single` of (OperaResponse?, T) for the current request. Notice that T conforms to OperaDecodable. If something goes wrong a Opera.Error error is propagated through the result sequence.
+
+     - parameter keyPath: keyPath to look up json object to serialize. Ignore parameter or pass nil when json object is the json root item.
+
+     - returns: An instance of `Single<(OperaResponse?, T)>`
+     */
+    public func objectResponse<T: OperaDecodable>(_ keyPath: String? = nil) -> Single<(OperaResponse?, T)> {
+        if base.manager.useMockedData && base.mockedData != nil {
+            return (base.manager as! RxManager).rx.sampleObjectResponse(base, keyPath: keyPath)
+        }
+        return (base.manager as! RxManager).rx.objectResponse(base, keyPath: keyPath)
+    }
+    /**
+     Returns a `Single` of (OperaResponse?, [T]) for the current request. Notice that T conforms to OperaDecodable. If something goes wrong a Opera.Error error is propagated through the result sequence.
+
+     - parameter collectionKeyPath: keyPath to look up json array to serialize. Ignore parameter or pass nil when json array is the json root item.
+
+     - returns: An instance of `Single<(OperaResponse?, [T])>`
+     */
+    public func collectionResponse<T: OperaDecodable>(_ collectionKeyPath: String? = nil) -> Single<(OperaResponse?, [T])> {
+        if base.manager.useMockedData && base.mockedData != nil {
+            return (base.manager as! RxManager).rx.sampleCollectionResponse(base, collectionKeyPath: collectionKeyPath)
+        }
+        return (base.manager as! RxManager).rx.collectionResponse(base, collectionKeyPath: collectionKeyPath)
+    }
 
 }
 

--- a/Sources/Common/RouteType+Rx.swift
+++ b/Sources/Common/RouteType+Rx.swift
@@ -28,6 +28,9 @@ import Foundation
 import RxCocoa
 import RxSwift
 
+public typealias OperaObjectResult<T> = (response: OperaResponse?, object: T)
+public typealias OperaCollectionResult<T> = (response: OperaResponse?, object: [T])
+
 extension Reactive where Base: RouteType {
 
     /**
@@ -88,7 +91,7 @@ extension Reactive where Base: RouteType {
 
      - returns: An instance of `Single<(OperaResponse?, T)>`
      */
-    public func objectResponse<T: OperaDecodable>(_ keyPath: String? = nil) -> Single<(OperaResponse?, T)> {
+    public func objectResponse<T: OperaDecodable>(_ keyPath: String? = nil) -> Single<OperaObjectResult<T>> {
         if base.manager.useMockedData && base.mockedData != nil {
             return (base.manager as! RxManager).rx.sampleObjectResponse(base, keyPath: keyPath)
         }
@@ -101,7 +104,7 @@ extension Reactive where Base: RouteType {
 
      - returns: An instance of `Single<(OperaResponse?, [T])>`
      */
-    public func collectionResponse<T: OperaDecodable>(_ collectionKeyPath: String? = nil) -> Single<(OperaResponse?, [T])> {
+    public func collectionResponse<T: OperaDecodable>(_ collectionKeyPath: String? = nil) -> Single<OperaCollectionResult<T>> {
         if base.manager.useMockedData && base.mockedData != nil {
             return (base.manager as! RxManager).rx.sampleCollectionResponse(base, collectionKeyPath: collectionKeyPath)
         }

--- a/Sources/Common/RxManager.swift
+++ b/Sources/Common/RxManager.swift
@@ -71,6 +71,43 @@ extension Reactive where Base: RxManager {
             }
         }
     }
+    /**
+     Returns a `Single` of (OperaResponse?,T) for the current request. Notice that T conforms to OperaDecodable. If something goes wrong an `OperaSwift.Error` error is propagated through the result sequence.
+
+     - parameter route: the route indicates the networking call that will be performed by including all the needed information like parameters, URL and HTTP method.
+     - parameter keyPath: keyPath to look up json object to serialize. Ignore parameter or pass nil when json object is the json root item.
+
+     - returns: An instance of `Single<(OperaResponse?,T)>`
+     */
+    func objectResponse<T: OperaDecodable>(_ route: RouteType, keyPath: String? = nil) -> Single<(OperaResponse?, T)> {
+        return base.rx.response(route).flatMap { operaResult -> Single<(OperaResponse?, T)> in
+            let serialized: DataResponse<T>  = operaResult.serializeObject(keyPath)
+            switch serialized.result {
+            case .failure(let error):
+                return Single.error(error)
+            case .success(let anyObject):
+                return Single.just((operaResult.operaResponse, anyObject))
+            }
+        }
+    }
+    /**
+     Returns a `Single` of (OperaResult?, [T]) for the current request. If something goes wrong an `OperaSwift.Error` error is propagated through the result sequence.
+     - parameter route: the route indicates the networking call that will be performed by including all the needed information like parameters, URL and HTTP method.
+     - parameter collectionKeyPath: keyPath to look up json array to serialize. Ignore parameter or pass nil when json array is the json root item.
+
+     - returns: An instance of `Single<(OperaResult?, [T])>`
+    */
+    func collectionResponse<T: OperaDecodable>(_ route: RouteType, collectionKeyPath: String? = nil) -> Single<(OperaResponse?, [T])> {
+        return base.rx.response(route).flatMap { operaResult -> Single<(OperaResponse?, [T])> in
+            let serialized: DataResponse<[T]> = operaResult.serializeCollection(collectionKeyPath)
+            switch serialized.result {
+            case .failure(let error):
+                return Single.error(error)
+            case .success(let anyObject):
+                return Single.just(operaResult.operaResponse, anyObject)
+            }
+        }
+    }
 
     /**
      Returns an `Single` of `OperaResult` for the current request. If something goes wrong an `OperaSwift.Error` error is propagated through the result sequence.
@@ -161,6 +198,30 @@ extension Reactive where Base: RxManager {
      */
     func sampleCompletableResponse(_ route: RouteType) -> Completable {
         return Completable.empty()
+    }
+    /**
+     Returns a `Single` of (OperaResponse?, T) for the current RouteType. Notice that T conforms to OperaDecodable. If something goes wrong an `OperaSwift.Error` error is propagated through the result sequence.
+
+     - parameter keyPath: keyPath to look up json object to serialize. Ignore parameter or pass nil when json object is the json root item.
+
+     - returns: An instance of `Single<(OperaResponse?, T)>` filled with sample data specified on the RouteType.
+     */
+    func sampleObjectResponse<T: OperaDecodable>(_ route: RouteType, keyPath: String? = nil) -> Single<(OperaResponse?, T)> {
+        return sampleObject(route, keyPath: keyPath).flatMap { object -> Single<(OperaResponse?, T)> in
+            return Single.just((nil, object))
+        }
+    }
+    /**
+     Returns a `Single` of (OpeaResponse?, [T]) for for the current RouteType. Notice that T conforms to OperaDecodable. If something goes wrong an `OperaSwift.Error` error is propagated through the result sequence.
+
+     - parameter collectionKeyPath: keyPath to look up json array to serialize. Ignore parameter or pass nil when json array is the json root item.
+
+     - returns: An instance of `Single<(OpeaResponse?, [T])>`  filled with sample data specified on the RouteType.
+     */
+    func sampleCollectionResponse<T: OperaDecodable>(_ route: RouteType, collectionKeyPath: String? = nil) -> Single<(OperaResponse?, [T])> {
+        return sampleCollection(route, collectionKeyPath: collectionKeyPath).flatMap { collection -> Single<(OperaResponse?, [T])> in
+            return Single.just((nil, collection))
+        }
     }
 
 }

--- a/Sources/Common/RxManager.swift
+++ b/Sources/Common/RxManager.swift
@@ -79,14 +79,14 @@ extension Reactive where Base: RxManager {
 
      - returns: An instance of `Single<(OperaResponse?,T)>`
      */
-    func objectResponse<T: OperaDecodable>(_ route: RouteType, keyPath: String? = nil) -> Single<(OperaResponse?, T)> {
-        return base.rx.response(route).flatMap { operaResult -> Single<(OperaResponse?, T)> in
+    func objectResponse<T: OperaDecodable>(_ route: RouteType, keyPath: String? = nil) -> Single<OperaObjectResult<T>> {
+        return base.rx.response(route).flatMap { operaResult -> Single<OperaObjectResult<T>> in
             let serialized: DataResponse<T>  = operaResult.serializeObject(keyPath)
             switch serialized.result {
             case .failure(let error):
                 return Single.error(error)
             case .success(let anyObject):
-                return Single.just((operaResult.operaResponse, anyObject))
+                return Single.just(OperaObjectResult(operaResult.operaResponse, anyObject))
             }
         }
     }
@@ -97,14 +97,14 @@ extension Reactive where Base: RxManager {
 
      - returns: An instance of `Single<(OperaResult?, [T])>`
     */
-    func collectionResponse<T: OperaDecodable>(_ route: RouteType, collectionKeyPath: String? = nil) -> Single<(OperaResponse?, [T])> {
-        return base.rx.response(route).flatMap { operaResult -> Single<(OperaResponse?, [T])> in
+    func collectionResponse<T: OperaDecodable>(_ route: RouteType, collectionKeyPath: String? = nil) -> Single<OperaCollectionResult<T>> {
+        return base.rx.response(route).flatMap { operaResult -> Single<OperaCollectionResult<T>> in
             let serialized: DataResponse<[T]> = operaResult.serializeCollection(collectionKeyPath)
             switch serialized.result {
             case .failure(let error):
                 return Single.error(error)
             case .success(let anyObject):
-                return Single.just(operaResult.operaResponse, anyObject)
+                return Single.just(OperaCollectionResult(operaResult.operaResponse, anyObject))
             }
         }
     }
@@ -206,9 +206,9 @@ extension Reactive where Base: RxManager {
 
      - returns: An instance of `Single<(OperaResponse?, T)>` filled with sample data specified on the RouteType.
      */
-    func sampleObjectResponse<T: OperaDecodable>(_ route: RouteType, keyPath: String? = nil) -> Single<(OperaResponse?, T)> {
-        return sampleObject(route, keyPath: keyPath).flatMap { object -> Single<(OperaResponse?, T)> in
-            return Single.just((nil, object))
+    func sampleObjectResponse<T: OperaDecodable>(_ route: RouteType, keyPath: String? = nil) -> Single<OperaObjectResult<T>> {
+        return sampleObject(route, keyPath: keyPath).flatMap { object -> Single<OperaObjectResult<T>> in
+            return Single.just(OperaObjectResult(nil, object))
         }
     }
     /**
@@ -218,9 +218,9 @@ extension Reactive where Base: RxManager {
 
      - returns: An instance of `Single<(OpeaResponse?, [T])>`  filled with sample data specified on the RouteType.
      */
-    func sampleCollectionResponse<T: OperaDecodable>(_ route: RouteType, collectionKeyPath: String? = nil) -> Single<(OperaResponse?, [T])> {
-        return sampleCollection(route, collectionKeyPath: collectionKeyPath).flatMap { collection -> Single<(OperaResponse?, [T])> in
-            return Single.just((nil, collection))
+    func sampleCollectionResponse<T: OperaDecodable>(_ route: RouteType, collectionKeyPath: String? = nil) -> Single<OperaCollectionResult<T>> {
+        return sampleCollection(route, collectionKeyPath: collectionKeyPath).flatMap { collection -> Single<OperaCollectionResult<T>> in
+            return Single.just(OperaCollectionResult(nil, collection))
         }
     }
 


### PR DESCRIPTION
Closes #37 
Added new routeType and rxManager helpers to make accessing the OperaResponse value easier.
Now we have `objectResponse` and `collectionResponse` that return a tuple of the decoded object and the Response. This way we keep opera's main functionality and we are also able to access the request headers, status code, etc if you need so (for parsing session headers for example).