### PR TITLE
Fix cocoapods repo name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ Follow these 4 steps to run Example project:
 To install Opera, simply add the following line to your Podfile:
 
 ```ruby
-pod 'Opera', '~> 2.0'
+pod 'OperaSwift', '~> 2.0'
 ```
 
 #### Carthage


### PR DESCRIPTION
Just changed pod install instructions in README.
'Opera' is giving the following error:
```shell
[!] Unable to satisfy the following requirements
```

Changed it to 'OperaSwift' and it is not giving error anymore.