### PR TITLE
Change dependencies

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "ReactiveX/RxSwift" "4.0.0-beta.0"
+github "ReactiveX/RxSwift" "4.0.0-rc.0"
 github "Alamofire/Alamofire" ~> 4.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,5 +1,5 @@
 github "Alamofire/Alamofire" "4.5.1"
 github "Anviking/Decodable" "0.6.0"
 github "Hearst-DD/ObjectMapper" "3.0.0"
-github "ReactiveX/RxSwift" "4.0.0-beta.0"
+github "ReactiveX/RxSwift" "4.0.0-rc.0"
 github "malcommac/SwiftDate" "4.4.1"

--- a/OperaSwift.podspec
+++ b/OperaSwift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "OperaSwift"
-  s.version          = "3.0.1-beta.0"
+  s.version          = "3.0.1-beta.1"
   s.summary          = "Protocol-Oriented Network abstraction layer written in Swift 4."
   s.homepage         = "https://github.com/xmartlabs/Opera"
   s.license          = { type: 'MIT', file: 'LICENSE' }
@@ -15,6 +15,6 @@ Pod::Spec.new do |s|
   s.source_files = 'Sources/Common/**/*.swift'
   s.ios.source_files = 'Sources/iOS/**/*.swift'
   s.dependency 'Alamofire', '~> 4.0'
-  s.dependency 'RxSwift', '4.0.0-beta.0'
-  s.dependency 'RxCocoa', '4.0.0-beta.0'
+  s.dependency 'RxSwift', '4.0.0-rc.0'
+  s.dependency 'RxCocoa', '4.0.0-rc.0'
 end


### PR DESCRIPTION
Change RxSwift and RxCocoa dependencies to “4.0.0-rc.0”.
The mentioned version is required in RxSwift dependencies.